### PR TITLE
Remove hardcoded MAC address

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,25 @@ It should work on any Linux with a working BlueZ install.  Most of my testing an
 * Install [bluepy](https://github.com/IanHarvey/bluepy) (it's not currently on pypi and needs to be manually installed).
 * `pip install pycirculate`
 
+## Usage
+```python
+from pycirculate.anova import AnovaController
+
+# Your device's MAC address can be found with `sudo hcitool lescan`
+anova = AnovaController("84:EB:18:6E:xx:xx")
+
+anova.read_unit()
+# -> 'c'
+anova.read_temp()
+# -> '14.9'
+
+anova.set_temp(63.5)
+anova.start_anova()
+
+anova.anova_status()
+# -> 'running'
+```
+
 ## Status
 
 *Alpha* -- everything seems to work, but needs more testing.

--- a/pycirculate/anova.py
+++ b/pycirculate/anova.py
@@ -24,8 +24,8 @@ class AnovaDelegate(btle.DefaultDelegate):
 
 
 class AnovaController(object):
-    def __init__(self):
-        self.anova = btle.Peripheral("78:A5:04:38:B3:FA")
+    def __init__(self, mac_address):
+        self.anova = btle.Peripheral(mac_address)
         self.anova.setDelegate(AnovaDelegate())
         # Service UUID:        0xFFE0
         services = self.anova.getServices()


### PR DESCRIPTION
Thanks for the library! It worked perfectly after I swapped in my Anova's MAC address.

This PR lets you specify the device MAC address when creating an `AnovaController`. I looked into adding a method to scan for available devices, but scanning for BTLE devices appears to require root permissions so I've left that out.

I've also added some quick usage examples to README.md.
